### PR TITLE
Fix wrong package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Convert [PlantUML] diagram text to SVG.
 ## Installation
 
 ```bash
-$ npm install metalsmith-plantuml
+$ npm install plantuml
 ```
 
 ## Usage


### PR DESCRIPTION
I think the package name should be plantuml instead of metalsmith-plantuml which seems to be a different package.